### PR TITLE
Expand pow(#, 2) to optimize math in nx_touch

### DIFF
--- a/nx_main/nx_touch.c
+++ b/nx_main/nx_touch.c
@@ -14,7 +14,7 @@
 #define LAUNCH_BUTTON_START_X 1092
 #define LAUNCH_BUTTON_END_X 1200
 
-#define distance(x1, y1, x2, y2) (int) sqrt(pow(x2 - x1, 2) + pow(y2 - y1, 2))
+#define distance(x1, y1, x2, y2) (int) sqrt(((x2 - x1) * (x2 - x1)) + ((y2 - y1) * (y2 - y1)))
 
 struct touchInfo_s touchInfo;
 


### PR DESCRIPTION
Factoring out the pow 2's to just use multiplies changes the assembly from floating-point math operations to fixed-point math operations for the multiply and add.

Quick example of old vs new:
```236  2ac: 1e620021  scvtf d1, w1                             <>
237  2b0: 1e620000  scvtf d0, w0
238  2b4: 1e610821  fmul d1, d1, d1                             236  2ac: 1b017c21  mul w1, w1, w1
239  2b8: 1f400400  fmadd d0, d0, d0, d1                        237  2b0: 1b000400  madd w0, w0, w0, w1
                                                                238  2b4: 1e620000  scvtf d0, w0
240  2bc: 1e602008  fcmp d0, #0.0                               239  2b8: 1e602008  fcmp d0, #0.0
241  2c0: 1e61c008  fsqrt d8, d0                                240  2bc: 1e61c008  fsqrt d8, d0
242  2c4: 540006c4  b.mi 39c <handleTouch+0x39c>  // b.first    241  2c0: 540006a4  b.mi 394 <handleTouch+0x394>  // b.first
```

All that said, I'm not that familiar with the switch's processor, so maybe there's some pipeline for this type of operation that makes this unnecessary.