### PR TITLE
Clarify build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,26 @@
-#### Usage
+### Usage
 See [Homebrew_Applications](https://switchbrew.org/wiki/Homebrew_Applications) for SD layout and applications, etc. See [Switchbrew](https://switchbrew.org/wiki/Homebrew_Menu) for hbmenu docs.
 
-#### Download
+### Download
 The latest release is available from the [releases](https://github.com/switchbrew/nx-hbmenu/releases/latest) page.
 
-#### Building
-Build with ```make nx``` or just run ```make```.
+### Building
+Build for the Nintendo Switch with ```make nx``` and for the PC with ```make pc```.
+Running ```make``` builds for both systems.
 
-The following is required to build: libfreetype (switch-freetype), libconfig (switch-libconfig), and libjpeg-turbo (switch-libjpeg-turbo). Where "({name})" is the pacman package. For the pc-build libminizip is required (for the Switch build, the switch-zlib package includes this).
+The following [pacman packages](https://devkitpro.org/wiki/devkitPro_pacman) are required to build:
+- `switch-dev`
+- `switch-freetype`
+- `switch-libconfig`
+- `switch-libjpeg-turbo`
+- `switch-zlib`
+- `zip` (on Windows)
 
-C11-threads are used, hence building for the pc-build may fail if C11-threads are not available.
+For the PC build, `libminizip` is required (for the Switch build, the `switch-zlib` package includes this).
+
+Since C11 threads are used, building for the PC may fail if C11 threads are not available.
 
 #### Credits
 
 * This uses code based on 3DS [new-hbmenu](https://github.com/fincs/new-hbmenu).
-* libjpeg-turbo is used for handling JPEG icons. This library doesn't support lossless JPEG (likewise for official sw which uses libjpeg-turbo).
+* `libjpeg-turbo` is used for handling JPEG icons. This library doesn't support lossless JPEG (likewise for official sw which uses `libjpeg-turbo`).


### PR DESCRIPTION
I felt that the given build instructions were not clear enough so I rewrote them. On `Windows` I was still missing the `zip` command to compile which is not mentioned in the `README` (installing switch-zlib does not suffice). This is related to [this](https://github.com/switchbrew/nx-hbmenu/issues/88) closed issue. Feel free to notify me of any errors I made in rewriting the `README` if you disagree with the pull request.

I did not compile for PC so I'm not sure if the given instructions make enough sense for someone to compile successfully without hassle.

Thank you.