### PR TITLE
Added SystemVersion to the homescreen

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -88,6 +88,7 @@ typedef enum
     ThemeLayoutId_MenuActiveEntryName,
     ThemeLayoutId_MenuActiveEntryAuthor,
     ThemeLayoutId_MenuActiveEntryVersion,
+    ThemeLayoutId_SystemVersion,
     ThemeLayoutId_Total,
 } ThemeLayoutId;
 

--- a/common/menu.c
+++ b/common/menu.c
@@ -565,6 +565,13 @@ void drawNetwork(int tmpX, AssetId id) {
     if (layoutobj->visible) drawIcon(layoutobj->posType ? tmpX + layoutobj->posStart[0] : layoutobj->posStart[0], layoutobj->posStart[1], data->imageSize[0], data->imageSize[1], data->buffer, themeCurrent.textColor);
 }
 
+void drawSystemVersion(){
+    char tmpstr[32];
+    u32 currentVersion = hosversionGet();
+    snprintf(tmpstr, sizeof(tmpstr)-1, "System v%d.%d.%d", HOSVER_MAJOR(currentVersion), HOSVER_MINOR(currentVersion), HOSVER_MICRO(currentVersion));
+    DrawTextFromLayout(ThemeLayoutId_SystemVersion, themeCurrent.textColor, tmpstr);
+}
+
 u32 drawStatus() {
     bool netstatusFlag=0;
     bool temperatureFlag=0;
@@ -597,6 +604,8 @@ u32 drawStatus() {
             DrawTextFromLayout(ThemeLayoutId_Temperature, themeCurrent.textColor, tmpstr);
         }
     }
+
+    drawSystemVersion();
 
     return tmpX;
 }

--- a/common/theme.c
+++ b/common/theme.c
@@ -404,6 +404,13 @@ void themeStartup(ThemePreset preset) {
                 .posStart = {1280 - 790, 135+10 + 28 + 30 + 18 + 6 + 18},
                 .font = interuiregular14,
             },
+
+            [ThemeLayoutId_SystemVersion] = {
+                .visible = true,
+                .posType = false,
+                .posStart = {40 + 2, 0 + 47 + 10 + 21 + 8},
+                .font = interuiregular14,
+            },
         },
     };
 


### PR DESCRIPTION
For my own reasons I've decided to add the system version of the Switch to the HBMenu. Not sure if this is desirable for everybody but I wanted to contribute this change. 

Ideally this shows the System version string exactly as it is in Settings, however I don't know how to obtain that information. 