### PR TITLE
Fix loader/builtin.c include relative path

### DIFF
--- a/nx_main/loaders/builtin.c
+++ b/nx_main/loaders/builtin.c
@@ -1,6 +1,6 @@
 #include <inttypes.h>
 
-#include "../common/common.h"
+#include "../../common/common.h"
 
 static char argBuf[ENTRY_ARGBUFSIZE];
 


### PR DESCRIPTION
This pull request includes a small change to the `nx_main/loaders/builtin.c` file. The change corrects the relative path for the `common.h` header file to ensure it is properly included.

* [`nx_main/loaders/builtin.c`](diffhunk://#diff-bf054641213800522b527b62e2011fb6cf750c52ec612f2be7a2e9f4b2422ce8L3-R3): Updated the include path for `common.h` from `../common/common.h` to `../../common/common.h`.

Currently, the build is not broken, but the relative path is incorrect. I am fixing it to prevent potential issues in the future where the build might fail due to the wrong path.